### PR TITLE
Better `install.bat` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,16 @@ That's it. Now make sure you have an OpenAI API key set.
 
 ## Installation script (Windows)
 
-For windows you can run `.\install.bat` (or double-click) after cloning the repo. It will do the following:
-1. Copies the necessary files to `~/yolo-ai-cmdbot/`
+For windows you can run `.\install.bat` (or double-click) after cloning the repo. By default it does the following:
+1. Copies the necessary files to `~\yolo-ai-cmdbot\`
 2. Creates a `yolo.bat` file in `~` that lets you run equivalent to `python.exe ~\yolo-ai-cmdbot\yolo.py`
 
+You will also have the option to:
+1. Change the location where `yolo-ai-cmdbot\` and `yolo.bat` will be created
+2. Skip creating `yolo-ai-cmdbot\` and use the folder of the cloned repository instead.
+3. Create a `.openai.apikey` and/or `.yolo-safety-off` file in your `~` directory
+
+That's it. Now make sure you have an OpenAI API key set.
 
 # macOS 
 
@@ -52,7 +58,9 @@ If you use `install.bat` you should have a `yolo.bat` file in your `~` directory
 
 `.\yolo.bat what is my username`
 
-you can put the `yolo.bat` file into a $PATH directory (like `C:\Windows\System32`) to use in any directory
+You can put the `yolo.bat` file into a $PATH directory (like `C:\Windows\System32`) to use in any directory like so:
+
+`yolo what is my username`
 
 Have fun.
 

--- a/install.bat
+++ b/install.bat
@@ -1,25 +1,164 @@
 @echo off
-:: Installs yolo in the user's home directory
+setlocal enabledelayedexpansion
+:: Note: "~" or %HOME% is equivalent to "%HOMEDRIVE%%HOMEPATH%\" but the latter is set in VM environments (from what I can tell)
 
-set TARGET_DIR= %HOME%yolo-ai-cmdbot
-set TARGET_FULLPATH= %TARGET_DIR%\yolo.py
+:: INSTALL_DIR = Directory the "yolo-ai-cmdbot\" will go to.
+:: SCRIPT_DIR = Directory the "yolo.bat" script will go to.
+:: createDIR = Whether or not a seperate "yolo-ai-cmdbot\" directory will be made/used to hold "yolo.py" and "prompt.txt". 1=Yes, 2=Just_use_Repo (the folder this is in)
+:: createAPIKEY = Whether to create a ".openai.apikey" at %HOMEDRIVE%%HOMEPATH%\. 1=Yes, 2=No
+:: createSafetyOff = Whether to create a ".yolo-safety-off" at %HOMEDRIVE%%HOMEPATH%\. 1=Yes, 2=No
 
-mkdir %TARGET_DIR%
-copy yolo.py %TARGET_DIR%
-copy prompt.txt %TARGET_DIR%
+:: Default values:
+set "INSTALL_DIR=%HOMEDRIVE%%HOMEPATH%\"
+set "SCRIPT_DIR=%HOMEDRIVE%%HOMEPATH%\"
+set /a "createDIR=1"
+set /a "createAPIKEY=2"
+set /a "createSafetyOff=2"
+set "installing=1"
 
-:: Windows: Creates a yolo.bat file into %HOME% directory which will let you run similar to Linux/MacOS
-:: Example: Input: ".\yolo.bat print hello" to "yolo print hello"
+:: Set Variables To User Defined If Needed 
+:: (This was as painful to make as it looks)
+choice /n /c YNCO /m "Do you want to install with default settings (or (C)ancel) (or create (O)ptional files)? <Y/N/C/O>:"
+set installing=%ERRORLEVEL%
+goto :choice_default_!ERRORLEVEL!
+:choice_default_2
+choice /n /c YN /m "Do you want to install a seperate 'yolo-ai-cmdbot\' directory (otherwise will use this repository folder)? <Y/N>:"
+set /a createDIR=%ERRORLEVEL%
+goto :choice_use_directory_!ERRORLEVEL!
+:choice_use_directory_1
+choice /n /c NY /m "Currently 'yolo-ai-cmdbot\' will be made in '!INSTALL_DIR!' . Is this OK? <Y/N>:"
+goto :choice_install_!ERRORLEVEL!
+:choice_install_1
+set /p INSTALL_DIR="Enter a path for 'yolo-ai-cmdbot\' to be made:"
+goto :choice_use_directory_1
+:choice_install_2
+:choice_use_directory_2
+choice /n /c NY /m "Currently 'yolo.bat' will be made in '!SCRIPT_DIR!' . Is this OK? <Y/N>:"
+goto :choice_script_!ERRORLEVEL!
+:choice_script_1
+set /p SCRIPT_DIR="Enter a path for 'yolo.bat' to be made:"
+goto :choice_use_directory_2
+:choice_script_2
+:choice_default_1
+set "TARGET_DIR=!INSTALL_DIR!\yolo-ai-cmdbot\"
+set "TARGET_FULLPATH=!TARGET_DIR!\yolo.py"
 
-:: yolo.bat can only be used in same directory; or, any directory if put in a $PATH directory (type $env:PATH in PowerShell and pick an appropriate path to paste in)
-:: C:\Windows\System32 is the $PATH directory everyone is likely to have
+::Actually Install
+cls
+if /i %createDIR%==1 ( call :install_yolo_directory ) else ( call :install_yolo_repository )
 
-:: Create yolo.bat and if it isn't already there input its code.
-find "@echo off" "%HOME%\yolo.bat" && (
-    echo "yolo.bat" Already Exists
-) || (
-    copy /y nul %HOME% yolo.bat
-    echo @echo off>>"%HOME%yolo.bat"
-    echo python.exe %HOME%yolo-ai-cmdbot\yolo.py %%*>>"%HOME%\yolo.bat"
-    echo Created "yolo.bat" in %HOME%
+::Optional files:
+:choice_default_4
+choice /n /c YN /m "Do you want to make a '.openai.apikey' file at %HOMEDRIVE%%HOMEPATH%\ to hold your apikey? <Y/N>:"
+set /a createAPIKEY=!ERRORLEVEL!
+choice /n /c YN /m "Do you want to make a '.yolo-safety-off' file at %HOMEDRIVE%%HOMEPATH%\ to disable safety? <Y/N>:"
+set /a createSafetyOff=!ERRORLEVEL!
+
+if /i !createAPIKEY!==1 ( call :create_openai_apikey )
+if /i !createSafetyOff!==1 ( call :create_safety_off )
+
+::Show a guide
+if /i !installing!==1 ( call :print_guide )
+if /i !installing!==2 ( call :print_guide )
+
+:choice_default_3
+pause
+goto :EOF
+
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+::                                              Functions                                                             ::
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+::                                             Installation                                                           ::
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: Installs yolo using created directory
+:install_yolo_directory
+echo Installing Yolo (Using Created Directory)
+call :create_yolo_directory
+call :create_yolo_bat_from_directory
+call :create_env_in_directory
+goto :EOF
+
+::Installs yolo using cloned repositiory
+:install_yolo_repository
+echo Installing Yolo (Using Cloned Repository)
+call :create_yolo_bat_from_repository
+call :create_env_in_repository
+goto :EOF
+
+:: Creates a directory to hold yolo.py and prompt.txt
+:create_yolo_directory
+echo Yolo Directory:
+echo Installing to !TARGET_DIR!
+mkdir !TARGET_DIR!
+copy  %~dp0\yolo.py !TARGET_DIR!
+copy  %~dp0\prompt.txt !TARGET_DIR!
+goto :EOF
+
+:: Create yolo.bat and input code linking to created directory
+:create_yolo_bat_from_directory
+echo Yolo Batch (Directory):
+echo yolo.py should be in !TARGET_DIR!...
+if not exist !TARGET_FULLPATH! ( echo Not Found: Aborting "create_yolo_bat_from_directory" ) else (
+    echo Found: Creating "yolo.bat" in !SCRIPT_DIR!
+    copy nul !SCRIPT_DIR!\yolo.bat
+    echo @echo off>!SCRIPT_DIR!\"yolo.bat"
+    echo python.exe !TARGET_DIR!\yolo.py %%*>>!SCRIPT_DIR!\"yolo.bat"
 )
+goto :EOF
+
+:: Create yolo.bat and input code linking to repository
+:create_yolo_bat_from_repository
+echo Yolo Batch (Repository):
+echo yolo.py should be in %~dp0...
+if not exist %~dp0\yolo.py ( echo Not Found: Aborting "create_yolo_bat_from_repository") else (
+    echo Found: Creating "yolo.bat" in !SCRIPT_DIR!
+    copy nul !SCRIPT_DIR!\yolo.bat
+    echo @echo off>!SCRIPT_DIR!\"yolo.bat"
+    echo python.exe %~dp0\yolo.py %%*>>!SCRIPT_DIR!\"yolo.bat"
+)
+goto :EOF
+
+:: Creates the safety off file and puts it in ~ for you
+:create_safety_off
+echo Yolo Safety Off:
+echo Creating ".yolo-safety-off" in %HOMEDRIVE%%HOMEPATH%\
+copy nul %HOMEDRIVE%%HOMEPATH%\.yolo-safety-off
+goto :EOF
+
+:: Creates the .openai.apikey if it doesn't already exists (otherwise, does nothing)
+:create_openai_apikey
+echo Yolo OpenAi ApiKey:
+echo Creating ".open.apikey" (if not already exists) in %HOMEDRIVE%%HOMEPATH%\
+copy nul %~dp0\.openai.apikey
+robocopy %~dp0 %HOMEDRIVE%%HOMEPATH%\ .openai.apikey /xc /xn /xo /nfl /ndl /njh /njs /nc /ns /np
+del .openai.apikey
+goto :EOF
+
+:: Creates the .env if it doesn't already exists in chosen install directory (otherwise, does nothing)
+:create_env_in_directory
+echo Yolo .Env:
+echo Creating ".env" (if not already exists) in !TARGET_DIR!
+if not exist %~dp0\.env ( copy nul %~dp0\.env  & robocopy %~dp0 !TARGET_DIR! .env /xc /xn /xo /nfl /ndl /njh /njs /nc /ns /np & del .env ) else ( robocopy %~dp0 !TARGET_DIR! .env /xc /xn /xo /nfl /ndl /njh /njs /nc /ns /np )
+goto :EOF
+
+:: Creates the .env if it doesn't already exists in chosen install directory (otherwise, does nothing)
+:create_env_in_repository
+echo Yolo .Env:
+echo Creating ".env" (if not already exists) in %~dp0
+if not exist %~dp0\.env ( copy nul %~dp0\.env ) else ( echo Already Exists )
+goto :EOF
+
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+::                                              General                                                               ::
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:print_guide
+echo ...
+echo Finished installing yolo-ai-cmdbot...
+echo You can run commands by being in the same directory as your "yolo.bat" file ( It is in !SCRIPT_DIR! ) with the following command:
+echo ".\yolo.bat <prompt>"
+echo You can also put your "yolo.bat" file into a $PATH directory and run it like so, instead:
+echo "yolo <prompt>"
+echo You should have "C:\Windows\System32" as a path in the $PATH environment variable but you can write the command "echo $env:PATH" into PowerShell for more options...
+goto :EOF


### PR DESCRIPTION
- Uses Functions
- Default and ...not default install options
- User can choose path for `yolo-ai-cmdbot\` and `yolo.bat`
- User can choose to create `.yolo-safety-off` and `.openai.apikey` if they choose to
- Terminal used for install messages
- Terminal used to display a guide